### PR TITLE
Add WireGuard peer endpoint updater

### DIFF
--- a/addon/dynip-ng.yml.example
+++ b/addon/dynip-ng.yml.example
@@ -37,6 +37,14 @@ destinations:
         template: /opt/caddy/etc/sites-enabled.gotmpl
         output: /opt/caddy/etc/sites-enabled
 
+    # re-resolve the endpoint of one or more WireGuard peers so
+    # the kernel stops sending UDP to the previously-cached IP
+    wireguard:
+        peers:
+            - interface: wg0
+              publicKey: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx="
+              port: 51820
+
 # configure logging
 # for supported configurations, check
 # https://github.com/els0r/log

--- a/addon/dynip.service
+++ b/addon/dynip.service
@@ -8,7 +8,19 @@ ExecStart=/opt/dynip/bin/dynip-ng run -c /opt/dynip/etc/dynip-ng.yaml
 StandardOutput=syslog
 Restart=on-failure
 
+# Minimum privileges needed to run `wg set ... endpoint ...` on a WireGuard
+# interface. Runs as an unprivileged user; CAP_NET_ADMIN is granted only to the
+# daemon process (and not inherited by children).
+User=dynip
+Group=dynip
+AmbientCapabilities=CAP_NET_ADMIN
+CapabilityBoundingSet=CAP_NET_ADMIN
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+ReadWritePaths=/var/run
+
 [Install]
 WantedBy=multi-user.target
 Alias=dnyip.service
-

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -59,6 +59,14 @@ attributes. For example the A record on Cloudflare.`,
 			updaters = append(updaters, fu)
 			logging.Get().Debug("Initialized file updates")
 		}
+		if dests.WireGuard != nil {
+			wu, err := update.NewWireGuardUpdate(dests.WireGuard)
+			if err != nil {
+				return err
+			}
+			updaters = append(updaters, wu)
+			logging.Get().Debug("Initialized WireGuard endpoint updates")
+		}
 
 		// prepare the state
 		state, err := state.New(config.State)

--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -64,6 +64,44 @@ type DestinationsConfig struct {
 	Cloudflare *CloudflareAPI `yaml:"cloudflare,omitempty"`
 	// configures the file update config
 	File *FileConfig `yaml:"file,omitempty"`
+	// configures WireGuard peer endpoint re-resolution
+	WireGuard *WireGuardConfig `yaml:"wireguard,omitempty"`
+}
+
+// WireGuardConfig configures which WireGuard peers should have their endpoint
+// re-resolved when a new IP is observed. The kernel caches the endpoint IP
+// per-peer, so `wg set <iface> peer <pubkey> endpoint <ip>:<port>` must be
+// invoked to point the tunnel at the fresh address.
+type WireGuardConfig struct {
+	Peers []WireGuardPeer `yaml:"peers"`
+}
+
+// WireGuardPeer identifies a single tunnel peer whose endpoint must be refreshed.
+type WireGuardPeer struct {
+	// Interface is the wg interface name (e.g. wg0).
+	Interface string `yaml:"interface"`
+	// PublicKey is the base64 peer public key as shown by `wg show`.
+	PublicKey string `yaml:"publicKey"`
+	// Port is the UDP listen port of the remote endpoint.
+	Port int `yaml:"port"`
+}
+
+func (w *WireGuardConfig) validate() error {
+	if len(w.Peers) == 0 {
+		return fmt.Errorf("wireguard: no peers provided")
+	}
+	for i, p := range w.Peers {
+		if p.Interface == "" {
+			return fmt.Errorf("wireguard: peer #%d: interface required", i)
+		}
+		if p.PublicKey == "" {
+			return fmt.Errorf("wireguard: peer #%d: publicKey required", i)
+		}
+		if p.Port <= 0 || p.Port > 65535 {
+			return fmt.Errorf("wireguard: peer #%d: port must be 1-65535", i)
+		}
+	}
+	return nil
 }
 
 // FileConfig stores parameters for
@@ -91,6 +129,9 @@ func (d DestinationsConfig) validate() error {
 	}
 	if d.File != nil {
 		sections = append(sections, d.File)
+	}
+	if d.WireGuard != nil {
+		sections = append(sections, d.WireGuard)
 	}
 	if len(sections) == 0 {
 		return fmt.Errorf("no destination for IP provided. Need at least one")

--- a/pkg/update/wireguard.go
+++ b/pkg/update/wireguard.go
@@ -1,0 +1,97 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os/exec"
+
+	"github.com/els0r/dynip-ng/pkg/cfg"
+	"github.com/els0r/dynip-ng/pkg/logging"
+	log "github.com/els0r/log"
+)
+
+// WireGuardUpdate re-resolves the endpoint of configured WireGuard peers by
+// invoking `wg set <iface> peer <pubkey> endpoint <ip>:<port>`. The kernel
+// caches the original endpoint address per peer, so a DNS change alone is not
+// enough to steer the tunnel at a new public IP.
+type WireGuardUpdate struct {
+	peers  []cfg.WireGuardPeer
+	wgBin  string
+	runner commandRunner
+	log    log.Logger
+}
+
+// commandRunner is an indirection around exec.CommandContext so the updater
+// can be unit-tested without a real wg binary.
+type commandRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+func defaultRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+// WGOption configures the WireGuard updater.
+type WGOption func(*WireGuardUpdate)
+
+// WithRunner swaps out the command runner. Intended for tests.
+func WithRunner(r commandRunner) WGOption {
+	return func(w *WireGuardUpdate) { w.runner = r }
+}
+
+// WithWGBinary overrides the wg binary path (default: "wg" resolved via PATH).
+func WithWGBinary(path string) WGOption {
+	return func(w *WireGuardUpdate) { w.wgBin = path }
+}
+
+// NewWireGuardUpdate constructs a new WireGuard endpoint updater.
+func NewWireGuardUpdate(c *cfg.WireGuardConfig, opts ...WGOption) (*WireGuardUpdate, error) {
+	if c == nil {
+		return nil, fmt.Errorf("wireguard: nil config")
+	}
+	w := &WireGuardUpdate{
+		peers:  c.Peers,
+		wgBin:  "wg",
+		runner: defaultRunner,
+		log:    logging.Get(),
+	}
+	for _, o := range opts {
+		o(w)
+	}
+	return w, nil
+}
+
+// Name returns a human-readable identifier for the updater.
+func (w *WireGuardUpdate) Name() string { return "wireguard updater" }
+
+// formatEndpoint builds the "host:port" string passed to `wg set ... endpoint`.
+// wg(8) requires IPv6 literals to be wrapped in square brackets.
+func formatEndpoint(ip string, port int) (string, error) {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return "", fmt.Errorf("not a valid IP: %q", ip)
+	}
+	if parsed.To4() == nil {
+		return fmt.Sprintf("[%s]:%d", parsed.String(), port), nil
+	}
+	return fmt.Sprintf("%s:%d", parsed.String(), port), nil
+}
+
+// Update re-resolves the endpoint of every configured WireGuard peer to the new IP.
+func (w *WireGuardUpdate) Update(ctx context.Context, ip string) error {
+	if ip == "" {
+		return fmt.Errorf("wireguard: empty IP")
+	}
+	for _, p := range w.peers {
+		endpoint, err := formatEndpoint(ip, p.Port)
+		if err != nil {
+			return err
+		}
+		args := []string{"set", p.Interface, "peer", p.PublicKey, "endpoint", endpoint}
+		w.log.Debugf("running %s %v", w.wgBin, args)
+		out, err := w.runner(ctx, w.wgBin, args...)
+		if err != nil {
+			return fmt.Errorf("wg set %s peer: %w (output=%q)", p.Interface, err, string(out))
+		}
+	}
+	return nil
+}

--- a/pkg/update/wireguard_test.go
+++ b/pkg/update/wireguard_test.go
@@ -1,0 +1,94 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/els0r/dynip-ng/pkg/cfg"
+)
+
+func TestFormatEndpoint(t *testing.T) {
+	cases := []struct {
+		ip   string
+		port int
+		want string
+		err  bool
+	}{
+		{"1.2.3.4", 51820, "1.2.3.4:51820", false},
+		{"2001:db8::1", 51820, "[2001:db8::1]:51820", false},
+		{"::1", 51820, "[::1]:51820", false},
+		{"not-an-ip", 51820, "", true},
+	}
+	for _, c := range cases {
+		got, err := formatEndpoint(c.ip, c.port)
+		if (err != nil) != c.err {
+			t.Fatalf("%s: err=%v want-err=%v", c.ip, err, c.err)
+		}
+		if got != c.want {
+			t.Fatalf("%s: got %q want %q", c.ip, got, c.want)
+		}
+	}
+}
+
+func TestWireGuardUpdate_InvokesWgSet(t *testing.T) {
+	var calls [][]string
+	fake := func(_ context.Context, name string, args ...string) ([]byte, error) {
+		calls = append(calls, append([]string{name}, args...))
+		return nil, nil
+	}
+
+	c := &cfg.WireGuardConfig{
+		Peers: []cfg.WireGuardPeer{
+			{Interface: "wg0", PublicKey: "ABCDEF=", Port: 51820},
+			{Interface: "wg1", PublicKey: "GHIJKL=", Port: 51821},
+		},
+	}
+	w, err := NewWireGuardUpdate(c, WithRunner(fake))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := w.Update(context.Background(), "203.0.113.5"); err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 invocations, got %d", len(calls))
+	}
+	want := "wg set wg0 peer ABCDEF= endpoint 203.0.113.5:51820"
+	if got := strings.Join(calls[0], " "); got != want {
+		t.Fatalf("call[0] got %q want %q", got, want)
+	}
+}
+
+func TestWireGuardUpdate_IPv6Brackets(t *testing.T) {
+	var captured []string
+	fake := func(_ context.Context, name string, args ...string) ([]byte, error) {
+		captured = append([]string{name}, args...)
+		return nil, nil
+	}
+	c := &cfg.WireGuardConfig{
+		Peers: []cfg.WireGuardPeer{{Interface: "wg0", PublicKey: "K=", Port: 51820}},
+	}
+	w, _ := NewWireGuardUpdate(c, WithRunner(fake))
+	if err := w.Update(context.Background(), "2001:db8::1"); err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(captured, " ")
+	if !strings.Contains(joined, "[2001:db8::1]:51820") {
+		t.Fatalf("expected bracketed v6 endpoint, got %q", joined)
+	}
+}
+
+func TestWireGuardUpdate_PropagatesError(t *testing.T) {
+	fake := func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return []byte("permission denied"), fmt.Errorf("exit 1")
+	}
+	c := &cfg.WireGuardConfig{Peers: []cfg.WireGuardPeer{{Interface: "wg0", PublicKey: "K=", Port: 51820}}}
+	w, _ := NewWireGuardUpdate(c, WithRunner(fake))
+	err := w.Update(context.Background(), "1.2.3.4")
+	if err == nil || !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("expected error carrying stderr, got %v", err)
+	}
+}


### PR DESCRIPTION
Re-resolves the endpoint of configured WireGuard peers when the external
IP changes, so kernel-cached stale endpoints don't break tunnels. New
updater implements the existing Updater interface and shells out to
`wg set <iface> peer <pubkey> endpoint <ip>:<port>`. IPv6 literals are
wrapped in square brackets.

Service unit drops to an unprivileged user with CAP_NET_ADMIN so the
daemon no longer needs full root to run `wg`.